### PR TITLE
avoid missing extra space in files

### DIFF
--- a/src/ssh-keygen.js
+++ b/src/ssh-keygen.js
@@ -91,9 +91,9 @@ function ssh_keygen(location, opts, callback){
 							fs.unlink(pubLocation, function(err){
 								if(err) return callback(err);
 								key = key.toString();
-								key = key.substring(0, key.lastIndexOf(" \n"));
+								key = key.substring(0, key.lastIndexOf("\n")).trim();
 								pubKey = pubKey.toString();
-								pubKey = pubKey.substring(0, pubKey.lastIndexOf(" \n"));
+								pubKey = pubKey.substring(0, pubKey.lastIndexOf("\n")).trim();
 								return callback(undefined, {
 									key: key, pubKey: pubKey
 								});


### PR DESCRIPTION
For many reasons, if the last space is missing in private or public key files, result of key and pubkey will be empty. 

This little patch fixe that.